### PR TITLE
Support multiple alohomora configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId
 auth-method = push
 ```
 
+You can create multiple configuration profiles in the ~/.alohomora file, for example:
+
+```
+[default]
+idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+auth-method = push
+role_name = a-fine-role
+
+[particularly-fine]
+idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+auth-method = push
+role_name = a-particularly-fine-role
+```
+
+To use the particularly-fine configuration, simply run `alohomora --config-name particularly-fine`.
+
+By default, alohomora loads the default configuration and saves the credentials under the saml profile.
+If a configuration other than default is specified, then alohomora saves the credentials under a profile
+named the same as the configuration name.
 
 ## Usage
 
@@ -80,7 +99,7 @@ select the device you want to use.
 
 ## Debugging
 
-Logs are written to `~/.alohomora` by default.
+Logs are written to `~/.alohomora.log` by default.
 
 
 ## Future Features

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -342,6 +342,7 @@ class DuoRequestsProvider(WebProvider):
 
     def _make_request(self, url, func, data=None, headers=None, soup=True):
         LOG.debug("Pre cookie jar: %s", self.session.cookies)
+        LOG.debug("Fetching from URL: %s", url)
         response = func(url, data=data, headers=headers)
         LOG.debug("Post cookie jar: %s", self.session.cookies)
         LOG.debug("Request headers: %s", response.request.headers)

--- a/bin/alohomora
+++ b/bin/alohomora
@@ -68,6 +68,9 @@ class Main(object):
         parser.add_argument("--idp-name",
                             help="Name of your SAML IdP, as registered with AWS",
                             default='sso')
+        parser.add_argument("--config-name",
+                            help="Name of the alohomora configuration to use",
+                            default="default")
         self.options = parser.parse_args()
 
         #
@@ -145,7 +148,18 @@ class Main(object):
                 principal_arn = selectedrole.split(',')[1]
 
         token = alohomora.keys.get(role_arn, principal_arn, assertion)
-        alohomora.keys.save(token)
+        profile = self.__get_config_name()
+        if profile == 'default':
+            # Cannot write default profile, so use function default profile name
+            alohomora.keys.save(token)
+        else:
+            alohomora.keys.save(token, profile=self.__get_config_name())
+
+    def __get_config_name(self):
+        """
+        Get the name of the alohomora configuration profile
+        """
+        return getattr(self.options, 'config_name')
 
     def _get_config(self, name, default):
         if hasattr(self.options, name) and getattr(self.options, name) is not None:
@@ -154,7 +168,7 @@ class Main(object):
             return data
 
         try:
-            data = self.config.get('default', name)
+            data = self.config.get(self.__get_config_name(), name)
             LOG.debug("%s is %s from config file", name, data)
             return data
         except ConfigParser.NoOptionError:


### PR DESCRIPTION
Support multiple alohomora configurations in the .alohomora file,
selected by using the --config-name flag.

Name the saved credentials' profile after the config name, unless the
config name is default, in which case continue to name the profile saml.

Update README.