### PR TITLE
Add --passwd to support piping password via stdin

### DIFF
--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -34,8 +34,14 @@ def die(msg):
     sys.exit(5)
 
 
-def _prompt_for_a_thing(msg, arr, func=lambda x: x):
+def _prompt_for_a_thing(msg, arr, func=lambda x: x, allow_interactive=None):
     """Given a list of items, ask the user to pick one"""
+    if allow_interactive == None:
+        raise Exception(
+            "_prompt_for_a_thing missing require arugment: allow_interactive")
+    elif not allow_interactive:
+        print("Prompt requested:", repr(msg))
+        die("However, refusing to prompt in non-interactive mode")
     print(msg)
     i = 0
     for thing in arr:

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -79,10 +79,11 @@ class WebProvider(object):
 
 class DuoRequestsProvider(WebProvider):
     """A requests-based provider of authentication data"""
-    def __init__(self, idp_url, auth_method=None):
+    def __init__(self, idp_url, auth_method=None, allow_interactive=True):
         self.session = None
         self.idp_url = idp_url
         self.auth_method = auth_method
+        self.allow_interactive = allow_interactive
 
     def login_one_factor(self, username, password):
         self.session = requests.Session()
@@ -290,7 +291,8 @@ class DuoRequestsProvider(WebProvider):
             device = alohomora._prompt_for_a_thing(
                 'Please select the device you want to authenticate with:',
                 devices,
-                lambda x: x.name
+                lambda x: x.name,
+                allow_interactive = self.allow_interactive
             )
         else:
             device = devices[0]
@@ -313,7 +315,8 @@ class DuoRequestsProvider(WebProvider):
                 if len(factors) > 1:
                     factor_name = alohomora._prompt_for_a_thing(
                         'Please select an authentication method',
-                        factors)
+                        factors,
+                        allow_interactive = self.allow_interactive)
 
                     factor = DuoFactor(factor_name)
                 else:

--- a/bin/alohomora
+++ b/bin/alohomora
@@ -87,6 +87,10 @@ class Main(object):
         parser.add_argument("--idp-name",
                             help="Name of your SAML IdP, as registered with AWS",
                             default='sso')
+        parser.add_argument("--passwd",
+                            help="Where to find the password",
+                            choices=['stdin', 'getpass'],
+                            default='getpass')
         self.options = parser.parse_args()
 
         #
@@ -119,7 +123,10 @@ class Main(object):
         if(not username):
             alohomora.die("Oops, don't forget to provide a username")
 
-        password = getpass.getpass()
+        if('getpass' == self._get_config('passwd', 'getpass')):
+            password = getpass.getpass()
+        else:
+            password = sys.stdin.readline().rstrip('\n')
 
         idp_url = self._get_config('idp-url', None)
         if(not idp_url):
@@ -130,7 +137,9 @@ class Main(object):
         #
         # Authenticate the user
         #
-        provider = alohomora.req.DuoRequestsProvider(idp_url, auth_method)
+        allow_interactive=('getpass' == self._get_config('passwd', 'getpass'))
+        provider = alohomora.req.DuoRequestsProvider(
+                idp_url, auth_method, allow_interactive=allow_interactive)
         (okay, response) = provider.login_one_factor(username, password)
         assertion = None
 
@@ -167,7 +176,8 @@ class Main(object):
                 selectedrole = alohomora._prompt_for_a_thing(
                     "Please choose the role you would like to assume:",
                     awsroles,
-                    lambda x: x.split(',')[0])
+                    lambda x: x.split(',')[0],
+                    allow_interactive=('getpass' == self._get_config('passwd', 'getpass')))
 
                 role_arn = selectedrole.split(',')[0]
                 principal_arn = selectedrole.split(',')[1]


### PR DESCRIPTION
This adds a new command-line flag --passwd that can be set to either "getpass" (current behavior and still default) or "stdin". Specifying "stdin" takes the password straight from stdin without prompting or requiring a tty, and causes prevents any other interactive prompts from happening.

The purpose of this is to allow scripted use of alohomora, where the password is collected from some other programmatic source, such as lpass-cli or similar.