### PR TITLE
Add [account_map] section to config to show friendly account names.

### DIFF
--- a/bin/alohomora
+++ b/bin/alohomora
@@ -100,6 +100,16 @@ class Main(object):
             print('Error reading your ~/.alohomora configuration file.')
             raise
 
+    def format_role(self, role_arn, account_map):
+        # arn:aws:iam::{{ accountid }}:role/{{ role_name }}
+        ARN,AWS,IAM,_,account_id,ROLE_SLASH_NAME = role_arn.split(':')
+        account_name = account_map.get(account_id)
+        if account_name:
+            role_name = role_arn.split("/")[-1]
+            return account_name + ": " + role_name + " - " + role_arn
+        else:
+            return role_arn
+
     def main(self):
         """Run the program."""
 
@@ -164,10 +174,17 @@ class Main(object):
                 role_arn = "arn:aws:iam::%s:role/%s" % (account_id, role_name)
                 principal_arn = "arn:aws:iam::%s:saml-provider/%s" % (account_id, idp_name)
             else:
+                account_map = {}
+                try:
+                    accounts = self.config.options('account_map')
+                    for account in accounts:
+                        account_map[account] = self.config.get('account_map', account)
+                except Exception:
+                    pass
                 selectedrole = alohomora._prompt_for_a_thing(
                     "Please choose the role you would like to assume:",
                     awsroles,
-                    lambda x: x.split(',')[0])
+                    lambda s: self.format_role(s.split(',')[0], account_map))
 
                 role_arn = selectedrole.split(',')[0]
                 principal_arn = selectedrole.split(',')[1]


### PR DESCRIPTION
This feature is compatible with account lookup. If a user has a local setting, that takes precedence. When account lookup is implemented, accounts not named by the user will be looked up (and potentially cached) as needed. If the user provides no entries in the [account_map] config section, the behavior is not changed from the current behavior.