### PR TITLE
Update aws_session_token to aws_security_token

### DIFF
--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -56,7 +56,7 @@ def save(token, profile='saml'):
 
     config.set(profile, 'aws_access_key_id', token['Credentials']['AccessKeyId'])
     config.set(profile, 'aws_secret_access_key', token['Credentials']['SecretAccessKey'])
-    config.set(profile, 'aws_session_token', token['Credentials']['SessionToken'])
+    config.set(profile, 'aws_security_token', token['Credentials']['SessionToken'])
 
     # Write the updated config file
     with open(filename, 'w+') as configfile:


### PR DESCRIPTION
Changed aws_session_token to aws_security_token for backwards compatibility in alohomora/keys.py. This saves ~/.aws/credentials as aws_security_token.  This change allows alohomora to work with Ansible modules.  
More info: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html