### PR TITLE
A Minor Readme update to ease Windows pain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Logs are written to `~/.alohomora.log` by default.
   * Provide some way of mapping account numbers to account names
 
 
+## Note for Windows Users
+
+This does **NOT** work in Cygwin or Cygwin based shells in Windows (such as Gitbash).  Use cmd instead.
+
+
 ## Thanks
 
 This application was written with heavy assistance from an 


### PR DESCRIPTION
Turns out Windows has some silly restrictions on the use of stdin by Cygwin shells which breaks getpass.  AFAIK the only way around this is to build a GUI, which is why this is just a readme update.