### PR TITLE
Multiple Alohomora profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ you're working in based off the roles that are handed back to us.
 However, if you're using the same IdP to provide access to both commercial and
 GovCloud, **and** you're asking Alohomora to do automatic role selection, it's
 hard for us to tell which partition you want to use.  You may need to manually
-specify that by adding an `aws_partition` option as below.
+specify that by adding an `aws-partition` option as below.
 
 ```ini
 [default]

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ You can create multiple configuration profiles in the ~/.alohomora file, for exa
 [default]
 idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
-role_name = a-fine-role
+role-name = a-fine-role
 
 [particularly-fine]
 idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
-role_name = a-particularly-fine-role
+role-name = a-particularly-fine-role
 ```
 
 If you specify nothing else, alohomora will use the `default` profile.  To use 
@@ -129,7 +129,7 @@ Or in a config file:
 ```ini
 [default]
 ...
-aws_profile = myprofile
+aws-profile = myprofile
 ```
 
 
@@ -172,7 +172,7 @@ configuration section like so:
 idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
 account = 112233445566
-role = sso-admins
+role-name = sso-admins
 ```
 
 
@@ -191,11 +191,11 @@ specify that by adding an `aws_partition` option as below.
 ```ini
 [default]
 ...
-aws_partition = aws
+aws-partition = aws
 
 [awsgov]
 ...
-aws_partition = aws-us-gov
+aws-partition = aws-us-gov
 ```
 
 Or, via the CLI:

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ but the choice is yours.
     pip install alohomora
 
 
-## Configuration
+## Basic Configuration
 
 You can create a ~/.alohomora file to configure the tool.  It will store
 infomation like the URL of your SAML Identity Provider that shouldn't change
-very often.  Alternately, you can specify any config option on the command line
-as well.
+very often.  Alternately, you can specify most config options on the command
+line as well.
 
 The file looks like a standard Python config file:
 
-```
+```ini
 [default]
 idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 username = myuser
@@ -33,65 +33,9 @@ username = myuser
 A CLI-based version of this would be
 
 ```
-alohomora --username myuser --idp-url https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+$ alohomora --username myuser --idp-url https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 ```
 
-In order to select a default device, you can add `auth-method` to the `default` 
-section of `~/.alohomora`. A nonexhaustive list of supported values are:
-- push
-- call
-- passcode
-
-```
-[default]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
-auth-method = push
-```
-
-## Account Names
-
-If you have many AWS accounts, keeping track of account IDs can be hard.  We've 
-added the ability to drop a map of account IDs to friendly names in the config
-file, that should help solve this problem.  To make use of this, add a new
-`[account_map]` section to the config like so:
-
-```
-[default]
-...
-
-[account_map]
-123456789012 = Dev Account
-210987654321 = Prod Account
-```
-
-This will modify the roles that get printed out, like so:
-
-```
-Please choose the role you would like to assume:
-[ 0 ] Dev Account: sso-admins - arn:aws:iam::123456789012:role/sso-admins
-[ 1 ] Prod Account: sso-finance-readers - arn:aws:iam::210987654321:role/sso-admins
-```
-
-## Automatic Account Selection
-
-If you have many AWS accounts/roles and wish to have alohomora always use a specific account and
-role, this can be done by specifying them in the configuration section like so:
-
-```
-[default]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
-auth-method = push
-account: 112233445566
-role: sso-admins
-```
-
-For govcloud accounts, govcloud must also be set along with the above options as follows:
-
-```
-[default]
-...
-govcloud: true
-```
 
 ## Usage
 
@@ -123,6 +67,144 @@ If you have multiple devices associated with your account, you will be asked to
 select the device you want to use.
 
 
+## Advanced Configuration
+
+
+### MFA Configuration for Duo
+
+In order to select a default Duo MFA device, you can add `auth-method` to your 
+configuration.  A nonexhaustive list of supported values for Duo are:
+
+- push
+- call
+- passcode
+
+```
+$ alohomora --auth-method call
+```
+
+```ini
+[default]
+idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+auth-method = push
+```
+
+
+### Alohomora Config Profiles
+
+You can create multiple configuration profiles in the ~/.alohomora file, for example:
+
+```ini
+[default]
+idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+auth-method = push
+role_name = a-fine-role
+
+[particularly-fine]
+idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+auth-method = push
+role_name = a-particularly-fine-role
+```
+
+If you specify nothing else, alohomora will use the `default` profile.  To use 
+the `particularly-fine` configuration, simply run 
+
+```
+$ alohomora --alohomora-profile particularly-fine
+```
+
+
+### AWS Config Profiles
+
+By default, alohomora saves the credentials under the `saml` profile.  If you 
+wish to save the generated IAM keys under a different AWS profile name, you can 
+specify the `aws-profile` option.  Via the CLI this looks like
+
+```
+alohomora --aws-profile myprofile
+```
+
+Or in a config file:
+
+```ini
+[default]
+...
+aws_profile = myprofile
+```
+
+
+### Account Names
+
+If you have many AWS accounts, keeping track of account IDs can be hard.  We've 
+added the ability to drop a map of account IDs to friendly names in the config
+file, that should help solve this problem.  To make use of this, add a new
+`[account_map]` section to the config like so:
+
+```ini
+[default]
+...
+
+[account_map]
+123456789012 = Dev Account
+210987654321 = Prod Account
+```
+
+This will modify the roles that get printed out, like so:
+
+```
+Please choose the role you would like to assume:
+[ 0 ] Dev Account: sso-admins - arn:aws:iam::123456789012:role/sso-admins
+[ 1 ] Prod Account: sso-finance-readers - arn:aws:iam::210987654321:role/sso-finance-readers
+```
+
+Alohomora doesn't support feeding these in via the command line, because that
+would make your command WAY too long.
+
+
+### Automatic Role Selection
+
+If you have many AWS accounts/roles and wish to have alohomora always use a 
+specific account and role, this can be done by specifying them in the 
+configuration section like so:
+
+```ini
+[default]
+idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+auth-method = push
+account = 112233445566
+role = sso-admins
+```
+
+
+### AWS Partition Selection
+
+If you run separate IdPs for your different commercial and GovCloud accounts, 
+alohomora should "just work": that is, the role lists will all update correctly,
+the assertions will be formatted properly, etc.  We autodiscover the partition
+you're working in based off the roles that are handed back to us.
+
+However, if you're using the same IdP to provide access to both commercial and
+GovCloud, **and** you're asking Alohomora to do automatic role selection, it's
+hard for us to tell which partition you want to use.  You may need to manually
+specify that by adding an `aws_partition` option as below.
+
+```ini
+[default]
+...
+aws_partition = aws
+
+[awsgov]
+...
+aws_partition = aws-us-gov
+```
+
+Or, via the CLI:
+
+```
+$ alohomora --aws-partition aws-us-gov
+```
+
+
 ## Debugging
 
 Logs are written to `~/.alohomora.log` by default.
@@ -131,8 +213,6 @@ Logs are written to `~/.alohomora.log` by default.
 ## Future Features
 
   * Respect the default factor option on the Duo account (push vs. text vs. call)
-  * Provide some way of mapping account numbers to account names
-
 
 ## Thanks
 

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -23,7 +23,7 @@ try:
 except NameError:
     pass
 
-__version__ = '1.3.3'
+__version__ = '1.4.0'
 __author__ = 'Stephan Kemper'
 __license__ = '(c) 2018 Viasat, Inc. See the LICENSE file for more details.'
 

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -46,7 +46,7 @@ def get(role_arn, principal_arn, assertion, duration):
     return token
 
 
-def save(token, profile='saml'):
+def save(token, profile):
     """Write the AWS STS token into the AWS credential file"""
     filename = os.path.expanduser("~/.aws/credentials")
 

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -355,6 +355,7 @@ class DuoRequestsProvider(WebProvider):
 
     def _make_request(self, url, func, data=None, headers=None, soup=True):
         LOG.debug("Pre cookie jar: %s", self.session.cookies)
+        LOG.debug("Fetching from URL: %s", url)
         response = func(url, data=data, headers=headers)
         LOG.debug("Post cookie jar: %s", self.session.cookies)
         LOG.debug("Request headers: %s", response.request.headers)

--- a/bin/alohomora
+++ b/bin/alohomora
@@ -35,6 +35,10 @@ from alohomora.keys import DURATION_MIN, DURATION_MAX
 import alohomora.req
 import alohomora.saml
 
+DEFAULT_AWS_PROFILE = 'saml'
+DEFAULT_ALOHOMORA_PROFILE = 'default'
+DEFAULT_IDP_NAME = 'sso'
+
 #
 # Set up logging
 #
@@ -51,19 +55,34 @@ def to_seconds(tstr):
     """Takes string in form of 3h/25m/13s/13 and returns integer seconds.
     No unit specified implies seconds."""
     try:
-        s, suffix = re.match("^([0-9]+)([HhMmSs]?)$", tstr).groups()
+        val, suffix = re.match("^([0-9]+)([HhMmSs]?)$", tstr).groups()
     except:
         alohomora.die("Can't parse duration '%s'" % tstr)
     scale = {'h': 3600, 'm': 60}.get(suffix.lower(), 1)
 
-    return int(s) * scale
+    return int(val) * scale
+
+
+def format_role(role_arn, account_map):
+    # arn:aws:iam::{{ accountid }}:role/{{ role_name }}
+    account_id = role_arn.split(':')[4]
+    account_name = account_map.get(account_id)
+    if account_name:
+        role_name = role_arn.split("/")[-1]
+        return account_name + ": " + role_name + " - " + role_arn
+    else:
+        return role_arn
+
 
 class Main(object):
     """Actually does stuff."""
 
     def __init__(self):
         #
-        # command line arguments
+        # We don't specify actual defaults here, so that we can try and load
+        # them from the config file later on.  Using None signals that the
+        # user didn't provide a value, and it's safe to look farther down the
+        # precedence tree.
         #
         parser = argparse.ArgumentParser()
         parser.add_argument("--username",
@@ -72,9 +91,9 @@ class Main(object):
         parser.add_argument("--idp-url",
                             help="The entry point for your SAML Identity Provider",
                             default=None)
-        parser.add_argument("--profile",
+        parser.add_argument("--aws-profile",
                             help="Save AWS credentials to specified profile",
-                            default="saml")
+                            default=None)
         parser.add_argument("--duration",
                             help="Request AWS token with specified duration",
                             default=None)
@@ -87,6 +106,12 @@ class Main(object):
         parser.add_argument("--idp-name",
                             help="Name of your SAML IdP, as registered with AWS",
                             default=None)
+        parser.add_argument("--aws-partition",
+                            help="Partition of AWS you're using, e.g. `aws-us-gov`",
+                            default=None)
+        parser.add_argument("--alohomora-profile",
+                            help="Name of the alohomora profile to use",
+                            default=DEFAULT_ALOHOMORA_PROFILE)
         self.options = parser.parse_args()
 
         #
@@ -100,16 +125,6 @@ class Main(object):
             print('Error reading your ~/.alohomora configuration file.')
             raise
 
-    def format_role(self, role_arn, account_map):
-        # arn:aws:iam::{{ accountid }}:role/{{ role_name }}
-        ARN,AWS,IAM,_,account_id,ROLE_SLASH_NAME = role_arn.split(':')
-        account_name = account_map.get(account_id)
-        if account_name:
-            role_name = role_arn.split("/")[-1]
-            return account_name + ": " + role_name + " - " + role_arn
-        else:
-            return role_arn
-
     def main(self):
         """Run the program."""
 
@@ -118,24 +133,24 @@ class Main(object):
 
         if not DURATION_MIN <= duration <= DURATION_MAX:
             alohomora.die("Duration of '%s' not in the range of %s-%s seconds" %
-                    (self._get_config('duration', None),
-                     DURATION_MIN,
-                     DURATION_MAX))
+                          (self._get_config('duration', None),
+                           DURATION_MIN,
+                           DURATION_MAX))
 
         #
         # Get the user's credentials
         #
         username = self._get_config('username', os.environ["USER"])
-        if(not username):
+        if not username:
             alohomora.die("Oops, don't forget to provide a username")
 
         password = getpass.getpass()
 
         idp_url = self._get_config('idp-url', None)
-        if(not idp_url):
+        if not idp_url:
             alohomora.die("Oops, don't forget to provide an idp-url")
 
-        auth_method = self._get_config('auth-method', None)
+        auth_method = self._get_config('auth_method', None)
 
         #
         # Authenticate the user
@@ -169,11 +184,14 @@ class Main(object):
             # arn:{{ partition }}:iam::{{ accountid }}:role/{{ role_name }}
             account_id = self._get_config('account', None)
             role_name = self._get_config('role_name', None)
-            idp_name = self._get_config('idp_name', 'sso')
-            is_govcloud = self._get_config('govcloud', '').lower() == "true"
+            idp_name = self._get_config('idp_name', DEFAULT_IDP_NAME)
+
+            # If the user has specified a partition, use it; otherwise, try autodiscovery
+            partition = self._get_config('aws_partition', None)
+            if partition is None:
+                partition = awsroles[0].split(':')[1]
 
             if account_id is not None and role_name is not None and idp_name is not None:
-                partition = 'aws-us-gov' if is_govcloud else 'aws'
                 role_arn = "arn:%s:iam::%s:role/%s" % (partition, account_id, role_name)
                 principal_arn = "arn:%s:iam::%s:saml-provider/%s" % (partition, account_id, idp_name)
             else:
@@ -187,13 +205,19 @@ class Main(object):
                 selectedrole = alohomora._prompt_for_a_thing(
                     "Please choose the role you would like to assume:",
                     awsroles,
-                    lambda s: self.format_role(s.split(',')[0], account_map))
+                    lambda s: format_role(s.split(',')[0], account_map))
 
                 role_arn = selectedrole.split(',')[0]
                 principal_arn = selectedrole.split(',')[1]
 
         token = alohomora.keys.get(role_arn, principal_arn, assertion, duration)
-        alohomora.keys.save(token,profile=self.options.profile)
+        alohomora.keys.save(token, profile=self._get_config('aws_profile', DEFAULT_AWS_PROFILE))
+
+    def __get_alohomora_profile_name(self):
+        """
+        Get the name of the alohomora configuration profile
+        """
+        return getattr(self.options, 'alohomora_profile')
 
     def _get_config(self, name, default):
         if hasattr(self.options, name) and getattr(self.options, name) is not None:
@@ -202,7 +226,7 @@ class Main(object):
             return data
 
         try:
-            data = self.config.get('default', name)
+            data = self.config.get(self.__get_alohomora_profile_name(), name)
             LOG.debug("%s is %s from config file", name, data)
             return data
         except ConfigParser.NoOptionError:
@@ -216,5 +240,4 @@ class Main(object):
         return data
 
 if __name__ == '__main__':
-    main = Main()
-    main.main()
+    Main().main()

--- a/bin/alohomora
+++ b/bin/alohomora
@@ -103,6 +103,9 @@ class Main(object):
         parser.add_argument("--role-name",
                             help="Name of the role you want to assume",
                             default=None)
+        parser.add_argument("--auth-method",
+                            help="How you want Duo to authenticate you",
+                            default=None)
         parser.add_argument("--idp-name",
                             help="Name of your SAML IdP, as registered with AWS",
                             default=None)
@@ -150,7 +153,7 @@ class Main(object):
         if not idp_url:
             alohomora.die("Oops, don't forget to provide an idp-url")
 
-        auth_method = self._get_config('auth_method', None)
+        auth_method = self._get_config('auth-method', None)
 
         #
         # Authenticate the user
@@ -183,11 +186,11 @@ class Main(object):
         elif len(awsroles) > 1:
             # arn:{{ partition }}:iam::{{ accountid }}:role/{{ role_name }}
             account_id = self._get_config('account', None)
-            role_name = self._get_config('role_name', None)
-            idp_name = self._get_config('idp_name', DEFAULT_IDP_NAME)
+            role_name = self._get_config('role-name', None)
+            idp_name = self._get_config('idp-name', DEFAULT_IDP_NAME)
 
             # If the user has specified a partition, use it; otherwise, try autodiscovery
-            partition = self._get_config('aws_partition', None)
+            partition = self._get_config('aws-partition', None)
             if partition is None:
                 partition = awsroles[0].split(':')[1]
 
@@ -211,7 +214,7 @@ class Main(object):
                 principal_arn = selectedrole.split(',')[1]
 
         token = alohomora.keys.get(role_arn, principal_arn, assertion, duration)
-        alohomora.keys.save(token, profile=self._get_config('aws_profile', DEFAULT_AWS_PROFILE))
+        alohomora.keys.save(token, profile=self._get_config('aws-profile', DEFAULT_AWS_PROFILE))
 
     def __get_alohomora_profile_name(self):
         """
@@ -220,8 +223,9 @@ class Main(object):
         return getattr(self.options, 'alohomora_profile')
 
     def _get_config(self, name, default):
-        if hasattr(self.options, name) and getattr(self.options, name) is not None:
-            data = getattr(self.options, name)
+        cli_name = name.replace('-', '_')
+        if hasattr(self.options, cli_name) and getattr(self.options, cli_name) is not None:
+            data = getattr(self.options, cli_name)
             LOG.debug("%s is %s from command line", name, data)
             return data
 


### PR DESCRIPTION
* Add support for config profiles
* rename --profile to --aws-profile
* allow different AWS partitions rather than hardcoding to GovCloud
* power-level the README