### PR TITLE
add aws_security_token and debug flag

### DIFF
--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -62,6 +62,7 @@ def save(token, profile):
     config.set(profile, 'aws_access_key_id', token['Credentials']['AccessKeyId'])
     config.set(profile, 'aws_secret_access_key', token['Credentials']['SecretAccessKey'])
     config.set(profile, 'aws_session_token', token['Credentials']['SessionToken'])
+    config.set(profile, 'aws_security_token', token['Credentials']['SessionToken'])
 
     # Write the updated config file
     with open(filename, 'w+') as configfile:

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -62,7 +62,6 @@ def save(token, profile):
     config.set(profile, 'aws_access_key_id', token['Credentials']['AccessKeyId'])
     config.set(profile, 'aws_secret_access_key', token['Credentials']['SecretAccessKey'])
     config.set(profile, 'aws_session_token', token['Credentials']['SessionToken'])
-    config.set(profile, 'aws_security_token', token['Credentials']['SessionToken'])
 
     # Write the updated config file
     with open(filename, 'w+') as configfile:

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -109,7 +109,14 @@ class DuoRequestsProvider(WebProvider):
                 # payload[name] = value
                 pass
         payload['_eventId_proceed'] = ''
-        LOG.debug(payload)
+        # Omit the password from the debug output...
+        payload_debugger = {}
+        for key in payload:
+            if "pass" in key.lower():
+                payload_debugger[key] = '****'
+            else:
+                payload_debugger[key] = payload[key]
+        LOG.debug(payload_debugger)
         if username not in payload.values():
             alohomora.die("Couldn't find right form field for username!")
         elif password not in payload.values():

--- a/bin/alohomora
+++ b/bin/alohomora
@@ -43,7 +43,7 @@ DEFAULT_IDP_NAME = 'sso'
 # Set up logging
 #
 logging.basicConfig(filename=os.path.expanduser('~/.alohomora.log'),
-                    level=logging.DEBUG,
+                    level=logging.WARN,
                     format='%(asctime)-15s %(levelname)-5s %(name)s %(message)s')
 logging.getLogger('botocore').setLevel(logging.WARN)
 logging.getLogger('boto3').setLevel(logging.WARN)
@@ -115,7 +115,15 @@ class Main(object):
         parser.add_argument("--alohomora-profile",
                             help="Name of the alohomora profile to use",
                             default=DEFAULT_ALOHOMORA_PROFILE)
+        parser.add_argument("--debug",
+                            action='store_true',
+                            help="Set the log level to debug",
+                            default=False)
         self.options = parser.parse_args()
+
+        # if debug is passed, set log level to DEBUG
+        if self.options.debug:
+            logging.getLogger("alohomora").setLevel(logging.DEBUG)
 
         #
         # config file


### PR DESCRIPTION
This sets the default log level to warn, and uses a flag to set to debug.  This also removes the password from the log output.  In addition, this adds the aws_secret_token to the credentials file as certain ansible modules still use boto which requires this.