### PR TITLE
Add u2f

### DIFF
--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -53,6 +53,21 @@ except NameError:
 LOG = logging.getLogger('alohomora.req')
 
 
+def get_u2f_devices():
+
+    devices = u2f.list_devices()
+    for device in devices:
+        try:
+            device.open()
+        except:
+            devices.remove(device)
+    return devices
+
+
+if not get_u2f_devices():
+    U2F_SUPPORT = False
+
+
 class DuoDevice(object):
     """A Duo authentication device"""
     def __init__(self, requests_thing):
@@ -107,13 +122,7 @@ class DuoRequestsProvider(WebProvider):
         #   },
         #   { ... }
         # ]
-        devices = u2f.list_devices()
-        for device in devices:
-            try:
-                device.open()
-            except:
-                devices.remove(device)
-
+        devices = get_u2f_devices()
         if not devices:
             raise IOError('no U2F devices found')
         #sys.stdout.write('Please tap your Security Key.')

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -180,7 +180,10 @@ class DuoRequestsProvider(WebProvider):
         finally:
             for device in devices:
                 device.close()
-        raise RuntimeWarning('U2F device not found')
+        answer = input('No registered U2F device found, retry? [Y/n]')
+        if answer == 'Y' or answer == 'y' or answer == '':
+            return self._get_u2f_response(reqs)
+        raise RuntimeWarning('No registered U2F device found')
 
     def login_one_factor(self, username, password):
         self.session = requests.Session()

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -128,6 +128,7 @@ class DuoRequestsProvider(WebProvider):
         #   },
         #   { ... }
         # ]
+        _ = input('Please ensure your security key is plugged in and hit enter...')
         devices = get_u2f_devices()
         if not devices:
             raise IOError('no U2F devices found')

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
         "boto3>=1.3.1",
         "beautifulsoup4>=4.5.1",
         "requests>=2.11.1",
+        "python-u2flib-host>=3.0.3",
     ],
 )


### PR DESCRIPTION
This adds support for U2F security keys with DUO. It uses the python-u2flib-host library to communicate with security keys, passing along the challenges that DUO exposes in the web integration. It will then make the response the same way that the web integration does.

I also went ahead and cleaned up all the existing pylint errors, so this is now a "clean build" project.