### PR TITLE
Do Python 3 the correct way. Fix bug saving credentials in [default]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ now.  Send us a PR with yours!
 Like all Python apps, we recommend you install this into a virtual environment,
 but the choice is yours.
 
-    pip install alohomora
+    pip3 install alohomora
 
 
 ## Basic Configuration

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -1,6 +1,7 @@
-"""Alohomora helper module"""
+''' The alohomora package
+'''
 
-# Copyright 2018 Viasat, Inc.
+# Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,47 +14,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
-
-import sys
-
-try:
-    input = raw_input
-except NameError:
-    pass
-
-__version__ = '2.0.3'
-__author__ = 'Stephan Kemper'
-__license__ = '(c) 2019 Viasat, Inc. See the LICENSE file for more details.'
-
-
-def die(msg):
-    """Exit with non-zero and a message"""
-    print(msg)
-    sys.exit(5)
-
-
-def _prompt_for_a_thing(msg, arr, func=lambda x: x):
-    """Given a list of items, ask the user to pick one"""
-    print(msg)
-    i = 0
-    for thing in arr:
-        print('[ %d ] %s' % (i, func(thing)))
-        i += 1
-    thing_index = _prompt_index(arr)
-    while thing_index is None:
-        print('You have entered an invalid ID')
-        thing_index = _prompt_index(arr)
-    return arr[thing_index]
-
-
-def _prompt_index(arr):
-    try:
-        device_index = int(input('ID: '))
-    except ValueError:
-        return None
-    if not 0 <= device_index <= (len(arr) - 1):
-        return None
-    else:
-        return device_index

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -54,6 +54,14 @@ def save(token, profile):
     config = ConfigParser.RawConfigParser()
     config.read(filename)
 
+    # This makes sure there is a [default] section if that's where
+    # the caller wants to put the profile. Don't ask me why this
+    # works when the config.has_section() test below doesn't. Config
+    # be strange.
+    #
+    if profile.lower() == 'default' and 'default' not in config.sections():
+        config.add_section('default')
+
     # Put the credentials into a saml specific section instead of clobbering
     # the default credentials
     if not config.has_section(profile):

--- a/alohomora/main.py
+++ b/alohomora/main.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-
+''' alohomora
+'''
 # Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -254,7 +254,3 @@ def main():
     ''' Do it. We need a regular function here for the setup.py console_scripts entry.
     '''
     Main().main()
-
-
-if __name__ == '__main__':
-    main()

--- a/alohomora/main.py
+++ b/alohomora/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2019 Viasat, Inc.
+# Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,10 +30,8 @@ except ImportError:
 
 
 import alohomora
-import alohomora.keys
+from alohomora import keys, req, saml
 from alohomora.keys import DURATION_MIN, DURATION_MAX
-import alohomora.req
-import alohomora.saml
 
 DEFAULT_AWS_PROFILE = 'saml'
 DEFAULT_ALOHOMORA_PROFILE = 'default'
@@ -166,7 +164,7 @@ class Main(object):
         #
         # Authenticate the user
         #
-        provider = alohomora.req.DuoRequestsProvider(idp_url, auth_method)
+        provider = req.DuoRequestsProvider(idp_url, auth_method)
         (okay, response) = provider.login_one_factor(username, password)
         assertion = None
 
@@ -181,7 +179,7 @@ class Main(object):
             LOG.info('One-factor OK')
             assertion = response
 
-        awsroles = alohomora.saml.get_roles(assertion)
+        awsroles = saml.get_roles(assertion)
 
         # If I have more than one role, ask the user which one they want,
         # otherwise just proceed
@@ -221,8 +219,8 @@ class Main(object):
                 role_arn = selectedrole.split(',')[0]
                 principal_arn = selectedrole.split(',')[1]
 
-        token = alohomora.keys.get(role_arn, principal_arn, assertion, duration)
-        alohomora.keys.save(token, profile=self._get_config('aws-profile', DEFAULT_AWS_PROFILE))
+        token = keys.get(role_arn, principal_arn, assertion, duration)
+        keys.save(token, profile=self._get_config('aws-profile', DEFAULT_AWS_PROFILE))
 
     def __get_alohomora_profile_name(self):
         """
@@ -251,5 +249,12 @@ class Main(object):
         LOG.debug("%s is %s from default", name, data)
         return data
 
-if __name__ == '__main__':
+
+def main():
+    ''' Do it. We need a regular function here for the setup.py console_scripts entry.
+    '''
     Main().main()
+
+
+if __name__ == '__main__':
+    main()

--- a/alohomora/main.py
+++ b/alohomora/main.py
@@ -29,9 +29,7 @@ except ImportError:
     import configparser as ConfigParser
 
 
-import alohomora
-from alohomora import keys, req, saml
-from alohomora.keys import DURATION_MIN, DURATION_MAX
+from . import utils, keys, req, saml
 
 DEFAULT_AWS_PROFILE = 'saml'
 DEFAULT_ALOHOMORA_PROFILE = 'default'
@@ -55,7 +53,7 @@ def to_seconds(tstr):
     try:
         val, suffix = re.match("^([0-9]+)([HhMmSs]?)$", tstr).groups()
     except:
-        alohomora.die("Can't parse duration '%s'" % tstr)
+        utils.die("Can't parse duration '%s'" % tstr)
     scale = {'h': 3600, 'm': 60}.get(suffix.lower(), 1)
 
     return int(val) * scale
@@ -140,24 +138,24 @@ class Main(object):
         # Validate options
         duration = to_seconds(self._get_config('duration', '1h'))
 
-        if not DURATION_MIN <= duration <= DURATION_MAX:
-            alohomora.die("Duration of '%s' not in the range of %s-%s seconds" %
+        if not keys.DURATION_MIN <= duration <= keys.DURATION_MAX:
+            utils.die("Duration of '%s' not in the range of %s-%s seconds" %
                           (self._get_config('duration', None),
-                           DURATION_MIN,
-                           DURATION_MAX))
+                           keys.DURATION_MIN,
+                           keys.DURATION_MAX))
 
         #
         # Get the user's credentials
         #
         username = self._get_config('username', os.getenv("USER"))
         if not username:
-            alohomora.die("Oops, don't forget to provide a username")
+            utils.die("Oops, don't forget to provide a username")
 
         password = getpass.getpass()
 
         idp_url = self._get_config('idp-url', None)
         if not idp_url:
-            alohomora.die("Oops, don't forget to provide an idp-url")
+            utils.die("Oops, don't forget to provide an idp-url")
 
         auth_method = self._get_config('auth-method', None)
 
@@ -173,7 +171,7 @@ class Main(object):
             LOG.info('We need to two-factor')
             (okay, response) = provider.login_two_factor(response)
             if not okay:
-                alohomora.die('Error doing two-factor, sorry.')
+                utils.die('Error doing two-factor, sorry.')
             assertion = response
         else:
             LOG.info('One-factor OK')
@@ -211,7 +209,7 @@ class Main(object):
                         account_map[account] = self.config.get('account_map', account)
                 except Exception:
                     pass
-                selectedrole = alohomora._prompt_for_a_thing(
+                selectedrole = utils._prompt_for_a_thing(
                     "Please choose the role you would like to assume:",
                     awsroles,
                     lambda s: format_role(s.split(',')[0], account_map))

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -35,9 +35,8 @@ except ImportError:
 
 import requests
 import os
-import alohomora
-
 from bs4 import BeautifulSoup
+from . import utils
 
 try:
     input = raw_input
@@ -118,9 +117,9 @@ class DuoRequestsProvider(WebProvider):
                 payload_debugger[key] = payload[key]
         LOG.debug(payload_debugger)
         if username not in payload.values():
-            alohomora.die("Couldn't find right form field for username!")
+            utils.die("Couldn't find right form field for username!")
         elif password not in payload.values():
-            alohomora.die("Couldn't find right form field for password!")
+            utils.die("Couldn't find right form field for password!")
 
         # Some IdPs don't explicitly set a form action, but if one is set we should
         # build the idpauthformsubmiturl by combining the scheme and hostname
@@ -142,7 +141,7 @@ class DuoRequestsProvider(WebProvider):
         # We need to check if the user actually got logged in
         # See if we have anything classed 'form-error'
         for tag in soup.find_all(lambda x: x.has_attr('class') and 'form-error' in x['class']):
-            alohomora.die(tag.get_text())
+            utils.die(tag.get_text())
 
         # Look for the SAMLResponse attribute of the input tag (determined by
         # analyzing the debug print lines above)
@@ -231,7 +230,7 @@ class DuoRequestsProvider(WebProvider):
         LOG.info(str(status_data))
         if status_data['stat'] != 'OK':
             LOG.error("Returned from inital status call: %s", status.text)
-            alohomora.die("Sorry, there was a problem talking to Duo.")
+            utils.die("Sorry, there was a problem talking to Duo.")
         print(status_data['response']['status'])
         allowed = status_data['response']['status_code'] == 'allow'
 
@@ -247,13 +246,13 @@ class DuoRequestsProvider(WebProvider):
 
             if status_data['stat'] != 'OK':
                 LOG.error("Returned from second status call: %s", status.text)
-                alohomora.die("Sorry, there was a problem talking to Duo.")
+                utils.die("Sorry, there was a problem talking to Duo.")
             if status_data['response']['status_code'] == 'allow':
                 LOG.info("Login allowed!")
                 allowed = True
             elif status_data['response']['status_code'] == 'deny':
                 LOG.error("Login disallowed: %s", status.text)
-                alohomora.die("The login was blocked!")
+                utils.die("The login was blocked!")
             else:
                 LOG.info("Still waiting... (%s)", status_data['response']['status_code'])
                 LOG.debug(str(status_data))
@@ -293,7 +292,7 @@ class DuoRequestsProvider(WebProvider):
         LOG.debug('Looking for the form action')
         form = soup.find('form')
         if form is None:
-            alohomora.die('Expected form not found, please make sure Duo is set up properly.{}Please check: {}'
+            utils.die('Expected form not found, please make sure Duo is set up properly.{}Please check: {}'
                           .format(os.linesep, self.idp_url))
         LOG.debug('Found form action %s', form['action'])
         return form['action']
@@ -314,7 +313,7 @@ class DuoRequestsProvider(WebProvider):
         devices = [dev for dev in devices if dev.value in supported_devices]
         LOG.debug("Acceptable devices: %s" % devices)
         if len(devices) > 1:
-            device = alohomora._prompt_for_a_thing(
+            device = utils._prompt_for_a_thing(
                 'Please select the device you want to authenticate with:',
                 devices,
                 lambda x: x.name
@@ -341,7 +340,7 @@ class DuoRequestsProvider(WebProvider):
                         factors = tmp_factors
 
                 if len(factors) > 1:
-                    factor_name = alohomora._prompt_for_a_thing(
+                    factor_name = utils._prompt_for_a_thing(
                         'Please select an authentication method',
                         factors)
 

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -33,9 +33,9 @@ except ImportError:
     from urllib.parse import unquote
 
 
-import alohomora
 import requests
 import os
+import alohomora
 
 from bs4 import BeautifulSoup
 

--- a/alohomora/utils.py
+++ b/alohomora/utils.py
@@ -1,0 +1,54 @@
+"""Alohomora helper module"""
+
+# Copyright 2018 Viasat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import sys
+
+try:
+    input = raw_input
+except NameError:
+    pass
+
+def die(msg):
+    """Exit with non-zero and a message"""
+    print(msg)
+    sys.exit(5)
+
+
+def _prompt_for_a_thing(msg, arr, func=lambda x: x):
+    """Given a list of items, ask the user to pick one"""
+    print(msg)
+    i = 0
+    for thing in arr:
+        print('[ %d ] %s' % (i, func(thing)))
+        i += 1
+    thing_index = _prompt_index(arr)
+    while thing_index is None:
+        print('You have entered an invalid ID')
+        thing_index = _prompt_index(arr)
+    return arr[thing_index]
+
+
+def _prompt_index(arr):
+    try:
+        device_index = int(input('ID: '))
+    except ValueError:
+        return None
+    if not 0 <= device_index <= (len(arr) - 1):
+        return None
+    else:
+        return device_index

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ setup(
     author=alohomora.__author__,
     author_email='vice@viasat.com',
     packages=['alohomora'],
-    scripts=['bin/alohomora'],
+    entry_points={
+        "console_scripts": [
+            "alohomora=alohomora.main:main",
+        ],
+    },
     url='https://github.com/Viasat/alohomora',
     license=alohomora.__license__,
     description="Get AWS API keys for a SAML-federated identity",

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import alohomora
-
 from setuptools import setup
 
 setup(
     name='alohomora',
-    version=alohomora.__version__,
-    author=alohomora.__author__,
+    version='2.1.0',
+    author='Stephan Kemper',
     author_email='vice@viasat.com',
     packages=['alohomora'],
     entry_points={
@@ -28,7 +26,7 @@ setup(
         ],
     },
     url='https://github.com/Viasat/alohomora',
-    license=alohomora.__license__,
+    license='(c) 2020 Viasat, Inc. See the LICENSE file for more details.',
     description="Get AWS API keys for a SAML-federated identity",
     install_requires=[
         "boto3>=1.3.1",


### PR DESCRIPTION
Changes:
- Using a shebang to choose the correct version of Python doesn't work, because PEP says `python3` should never be aliased as `python`. The correct way to install version-specific command-line tools is with the `setup.py` `console_scripts` construct. This PR moves `alomora` to `alohomora/main.py` and uses the aforementioned construct to call it.
- It's often convenient to store one's credentials in the `[default]` AWS profile, so that you don't have to specify the profile when using it. But a strangeness in the `Config` module prevented credentials from being stored there if the profile didn't already exist.
- Cleaned up relative imports, in part by moving code out of `__init__.py` to `utils.py`.