### PR TITLE
Do Python 3 the correct way. Fix bug saving credentials in [default]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ now.  Send us a PR with yours!
 Like all Python apps, we recommend you install this into a virtual environment,
 but the choice is yours.
 
-    pip install alohomora
+    pip3 install alohomora
 
 
 ## Basic Configuration

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -1,6 +1,7 @@
-"""Alohomora helper module"""
+''' The alohomora package
+'''
 
-# Copyright 2018 Viasat, Inc.
+# Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,47 +14,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
-
-import sys
-
-try:
-    input = raw_input
-except NameError:
-    pass
-
-__version__ = '2.0.3'
-__author__ = 'Stephan Kemper'
-__license__ = '(c) 2019 Viasat, Inc. See the LICENSE file for more details.'
-
-
-def die(msg):
-    """Exit with non-zero and a message"""
-    print(msg)
-    sys.exit(5)
-
-
-def _prompt_for_a_thing(msg, arr, func=lambda x: x):
-    """Given a list of items, ask the user to pick one"""
-    print(msg)
-    i = 0
-    for thing in arr:
-        print('[ %d ] %s' % (i, func(thing)))
-        i += 1
-    thing_index = _prompt_index(arr)
-    while thing_index is None:
-        print('You have entered an invalid ID')
-        thing_index = _prompt_index(arr)
-    return arr[thing_index]
-
-
-def _prompt_index(arr):
-    try:
-        device_index = int(input('ID: '))
-    except ValueError:
-        return None
-    if not 0 <= device_index <= (len(arr) - 1):
-        return None
-    else:
-        return device_index

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -54,6 +54,14 @@ def save(token, profile):
     config = ConfigParser.RawConfigParser()
     config.read(filename)
 
+    # This makes sure there is a [default] section if that's where
+    # the caller wants to put the profile. Don't ask me why this
+    # works when the config.has_section() test below doesn't. Config
+    # be strange.
+    #
+    if profile.lower() == 'default' and 'default' not in config.sections():
+        config.add_section('default')
+
     # Put the credentials into a saml specific section instead of clobbering
     # the default credentials
     if not config.has_section(profile):

--- a/alohomora/main.py
+++ b/alohomora/main.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
-
-# Copyright 2019 Viasat, Inc.
+''' alohomora
+'''
+# Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,11 +29,17 @@ except ImportError:
     import configparser as ConfigParser
 
 
-import alohomora
-import alohomora.keys
-from alohomora.keys import DURATION_MIN, DURATION_MAX
-import alohomora.req
-import alohomora.saml
+# This hack allows us to import our own modules either when debugging
+# this program locally with "python3 main.py ..." or when the program
+# runs as a regular script. In the latter case, the problem is that
+# the first entry in sys.path() is the directory of the stub created
+# by pip to call us, not our own directory. So by adding our own
+# directory to the path, we can find our modules.
+#
+if __name__ != "__main__":
+    sys.path.append(os.path.dirname(__file__))
+
+import utils, keys, req, saml
 
 DEFAULT_AWS_PROFILE = 'saml'
 DEFAULT_ALOHOMORA_PROFILE = 'default'
@@ -57,7 +63,7 @@ def to_seconds(tstr):
     try:
         val, suffix = re.match("^([0-9]+)([HhMmSs]?)$", tstr).groups()
     except:
-        alohomora.die("Can't parse duration '%s'" % tstr)
+        utils.die("Can't parse duration '%s'" % tstr)
     scale = {'h': 3600, 'm': 60}.get(suffix.lower(), 1)
 
     return int(val) * scale
@@ -142,31 +148,31 @@ class Main(object):
         # Validate options
         duration = to_seconds(self._get_config('duration', '1h'))
 
-        if not DURATION_MIN <= duration <= DURATION_MAX:
-            alohomora.die("Duration of '%s' not in the range of %s-%s seconds" %
+        if not keys.DURATION_MIN <= duration <= keys.DURATION_MAX:
+            utils.die("Duration of '%s' not in the range of %s-%s seconds" %
                           (self._get_config('duration', None),
-                           DURATION_MIN,
-                           DURATION_MAX))
+                           keys.DURATION_MIN,
+                           keys.DURATION_MAX))
 
         #
         # Get the user's credentials
         #
         username = self._get_config('username', os.getenv("USER"))
         if not username:
-            alohomora.die("Oops, don't forget to provide a username")
+            utils.die("Oops, don't forget to provide a username")
 
         password = getpass.getpass()
 
         idp_url = self._get_config('idp-url', None)
         if not idp_url:
-            alohomora.die("Oops, don't forget to provide an idp-url")
+            utils.die("Oops, don't forget to provide an idp-url")
 
         auth_method = self._get_config('auth-method', None)
 
         #
         # Authenticate the user
         #
-        provider = alohomora.req.DuoRequestsProvider(idp_url, auth_method)
+        provider = req.DuoRequestsProvider(idp_url, auth_method)
         (okay, response) = provider.login_one_factor(username, password)
         assertion = None
 
@@ -175,13 +181,13 @@ class Main(object):
             LOG.info('We need to two-factor')
             (okay, response) = provider.login_two_factor(response)
             if not okay:
-                alohomora.die('Error doing two-factor, sorry.')
+                utils.die('Error doing two-factor, sorry.')
             assertion = response
         else:
             LOG.info('One-factor OK')
             assertion = response
 
-        awsroles = alohomora.saml.get_roles(assertion)
+        awsroles = saml.get_roles(assertion)
 
         # If I have more than one role, ask the user which one they want,
         # otherwise just proceed
@@ -213,7 +219,7 @@ class Main(object):
                         account_map[account] = self.config.get('account_map', account)
                 except Exception:
                     pass
-                selectedrole = alohomora._prompt_for_a_thing(
+                selectedrole = utils._prompt_for_a_thing(
                     "Please choose the role you would like to assume:",
                     awsroles,
                     lambda s: format_role(s.split(',')[0], account_map))
@@ -221,8 +227,8 @@ class Main(object):
                 role_arn = selectedrole.split(',')[0]
                 principal_arn = selectedrole.split(',')[1]
 
-        token = alohomora.keys.get(role_arn, principal_arn, assertion, duration)
-        alohomora.keys.save(token, profile=self._get_config('aws-profile', DEFAULT_AWS_PROFILE))
+        token = keys.get(role_arn, principal_arn, assertion, duration)
+        keys.save(token, profile=self._get_config('aws-profile', DEFAULT_AWS_PROFILE))
 
     def __get_alohomora_profile_name(self):
         """
@@ -251,5 +257,12 @@ class Main(object):
         LOG.debug("%s is %s from default", name, data)
         return data
 
-if __name__ == '__main__':
+
+def main():
+    ''' Do it. We need a regular function here for the setup.py console_scripts entry.
+    '''
     Main().main()
+
+
+if __name__ == "__main__":
+    main()

--- a/alohomora/utils.py
+++ b/alohomora/utils.py
@@ -1,0 +1,54 @@
+"""Alohomora helper module"""
+
+# Copyright 2018 Viasat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import sys
+
+try:
+    input = raw_input
+except NameError:
+    pass
+
+def die(msg):
+    """Exit with non-zero and a message"""
+    print(msg)
+    sys.exit(5)
+
+
+def _prompt_for_a_thing(msg, arr, func=lambda x: x):
+    """Given a list of items, ask the user to pick one"""
+    print(msg)
+    i = 0
+    for thing in arr:
+        print('[ %d ] %s' % (i, func(thing)))
+        i += 1
+    thing_index = _prompt_index(arr)
+    while thing_index is None:
+        print('You have entered an invalid ID')
+        thing_index = _prompt_index(arr)
+    return arr[thing_index]
+
+
+def _prompt_index(arr):
+    try:
+        device_index = int(input('ID: '))
+    except ValueError:
+        return None
+    if not 0 <= device_index <= (len(arr) - 1):
+        return None
+    else:
+        return device_index

--- a/setup.py
+++ b/setup.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import alohomora
-
 from setuptools import setup
 
 setup(
     name='alohomora',
-    version=alohomora.__version__,
-    author=alohomora.__author__,
+    version='2.1.0',
+    author='Stephan Kemper',
     author_email='vice@viasat.com',
     packages=['alohomora'],
-    scripts=['bin/alohomora'],
+    entry_points={
+        "console_scripts": [
+            "alohomora=alohomora.main:main",
+        ],
+    },
     url='https://github.com/Viasat/alohomora',
-    license=alohomora.__license__,
+    license='(c) 2020 Viasat, Inc. See the LICENSE file for more details.',
     description="Get AWS API keys for a SAML-federated identity",
     install_requires=[
         "boto3>=1.3.1",


### PR DESCRIPTION
Changes:
- Using a shebang to choose the correct version of Python doesn't work, because PEP says `python3` should never be aliased as `python`. The correct way to install version-specific command-line tools is with the `setup.py` `console_scripts` construct. This PR moves `alomora` to `alohomora/main.py` and uses the aforementioned construct to call it.
- It's often convenient to store one's credentials in the `[default]` AWS profile, so that you don't have to specify the profile when using it. But a strangeness in the `Config` module prevented credentials from being stored there if the profile didn't already exist.
- Cleaned up relative imports, in part by moving code out of `__init__.py` to `utils.py`.