### PR TITLE
Make the utility a console_script; allow saving to [default]

### DIFF
--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -1,6 +1,6 @@
 """Alohomora helper module"""
 
-# Copyright 2018 Viasat, Inc.
+# Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ try:
 except NameError:
     pass
 
-__version__ = '2.0.3'
+__version__ = '2.1.0'
 __author__ = 'Stephan Kemper'
-__license__ = '(c) 2019 Viasat, Inc. See the LICENSE file for more details.'
+__license__ = '(c) 2020 Viasat, Inc. See the LICENSE file for more details.'
 
 
 def die(msg):

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -54,6 +54,14 @@ def save(token, profile):
     config = ConfigParser.RawConfigParser()
     config.read(filename)
 
+    # This makes sure there is a [default] section if that's where
+    # the caller wants to put the profile. Don't ask me why this
+    # works when the config.has_section() test below doesn't. Config
+    # be strange.
+    #
+    if profile.lower() == 'default' and 'default' not in config.sections():
+        config.add_section('default')
+
     # Put the credentials into a saml specific section instead of clobbering
     # the default credentials
     if not config.has_section(profile):

--- a/alohomora/main.py
+++ b/alohomora/main.py
@@ -1,6 +1,8 @@
-#!/usr/bin/env python
+'''
+alohomora console script
+'''
 
-# Copyright 2019 Viasat, Inc.
+# Copyright 2020 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -250,6 +252,13 @@ class Main(object):
         data = default
         LOG.debug("%s is %s from default", name, data)
         return data
+
+
+def main():
+    ''' do it
+    '''
+    Main().main()
+
 
 if __name__ == '__main__':
     Main().main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ setup(
     author=alohomora.__author__,
     author_email='vice@viasat.com',
     packages=['alohomora'],
-    scripts=['bin/alohomora'],
+    entry_points={
+        "console_scripts": [
+            "alohomora=alohomora.main:main",
+        ],
+    },
     url='https://github.com/Viasat/alohomora',
     license=alohomora.__license__,
     description="Get AWS API keys for a SAML-federated identity",


### PR DESCRIPTION
Changes:
- Using a shebang to choose the correct version of Python doesn't work, because PEP says `python3` should never be aliased as `python`. The correct way to install version-specific command-line tools is with the `setup.py` `console_scripts` construct. This PR moves `alomora` to `alohomora/main.py` and uses the aforementioned construct to call it.
- It's often convenient to store one's credentials in the `[default]` AWS profile, so that you don't have to specify the profile when using it. But a strangeness in the `Config` module prevented credentials from being stored there if the profile didn't already exist. This PR fixes the problem.
