### PR TITLE
Make u2f support an extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ but the choice is yours.
 
     pip install alohomora
 
+### Optional U2F support installation
+
+Alohomora has optional U2F support, which can be installed alongside alohomora using pip:
+
+    pip install alohomora[u2f]
+
+Please note that this requires a few OS level packages to be installed.
+For Centos 7, it requires the following:
+
+    yum groupinstall 'Development Tools'
+    yum install python[2,3]-devel
+    yum install libusbx-devel
+    yum install systemd-devel
+
+For Debian based systems, you'll need the following:
+
+    apt install build-essential
+    apt install python[2,3]-dev
+    apt install libusb-1.0-0-dev
+    apt install libudev-dev
 
 ## Basic Configuration
 

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -38,12 +38,13 @@ from bs4 import BeautifulSoup
 
 import alohomora
 
-U2F_SUPPORT = True
+U2F_SUPPORT = False
 try:
     from u2flib_host import u2f, exc
     from u2flib_host.constants import APDU_USE_NOT_SATISFIED, APDU_WRONG_DATA
+    U2F_SUPPORT = True
 except ImportError:
-    U2F_SUPPORT = False
+    pass
 
 try:
     input = raw_input #pylint: disable=redefined-builtin,invalid-name
@@ -65,8 +66,12 @@ def get_u2f_devices():
     return devices
 
 
-if not get_u2f_devices():
-    U2F_SUPPORT = False
+if U2F_SUPPORT:
+    try:
+        get_u2f_devices()
+        U2F_SUPPORT = True
+    except: # pylint: disable=bare-except
+        U2F_SUPPORT = False
 
 
 class DuoDevice(object):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
         "boto3>=1.3.1",
         "beautifulsoup4>=4.5.1",
         "requests>=2.11.1",
-        "python-u2flib-host>=3.0.3",
     ],
+    extras_require={
+        "u2f": ["python-u2flib-host>=3.0.3"]
+    }
 )


### PR DESCRIPTION
This makes U2F support install only if the user runs `pip install alohomora[u2f]`, rather than `pip install alohomora`.

Given the number of build-time dependencies on linux, this seems likely to remove a TON of headache. If someone really wants to install with u2f support, they can follow the README.