### PR TITLE
add graceful exit when duration mismatch

### DIFF
--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -23,8 +23,7 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
-import boto3
-
+import boto3, botocore
 
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_saml.html#troubleshoot_saml_duration-exceeds
 DURATION_MIN = 15*60
@@ -38,11 +37,19 @@ def get(role_arn, principal_arn, assertion, duration):
         client = session.client('sts')
     else:
         client = boto3.client('sts')
-    token = client.assume_role_with_saml(
-        RoleArn=role_arn,
-        PrincipalArn=principal_arn,
-        DurationSeconds=(duration),
-        SAMLAssertion=assertion)
+    
+    try:
+        token = client.assume_role_with_saml(
+            RoleArn=role_arn,
+            PrincipalArn=principal_arn,
+            DurationSeconds=(duration),
+            SAMLAssertion=assertion)
+    except botocore.exceptions.ClientError as error:
+        print (error.response['Error']['Code'], ":", error.response['Error']['Message'])
+        exit(1)  
+    except:
+        raise 
+        
     return token
 
 


### PR DESCRIPTION
When duration are mismatched between user provided versus AWS role permitted, an exception will be throw.  
Catching it and exit gracefully would help for new comers to understand exactly what happened. 