### PR TITLE
support for aws credential_process

### DIFF
--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -31,6 +31,10 @@ __url__ = 'https://github.com/Viasat/alohomora'
 __description__ = 'Get AWS API keys for a SAML-federated identity'
 
 
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
 def die(msg):
     """Exit with non-zero and a message"""
     print(msg)

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -16,7 +16,9 @@
 
 from __future__ import print_function
 
+import json
 import os
+from datetime import datetime, timezone
 
 try:
     import ConfigParser
@@ -25,10 +27,12 @@ except ImportError:
 
 import boto3
 
+import alohomora
 
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_saml.html#troubleshoot_saml_duration-exceeds
 DURATION_MIN = 15*60
 DURATION_MAX = 12*60*60
+
 
 def get(role_arn, principal_arn, assertion, duration):
     """Use the assertion to get an AWS STS token using Assume Role with SAML"""
@@ -48,6 +52,7 @@ def get(role_arn, principal_arn, assertion, duration):
 
 def save(token, profile):
     """Write the AWS STS token into the AWS credential file"""
+
     filename = os.path.expanduser("~/.aws/credentials")
 
     # Read in the existing config file
@@ -76,7 +81,82 @@ def save(token, profile):
         config.write(configfile)
 
     # Give the user some basic info as to what has just happened
-    print("""\n\n----------------------------------------------------------------
+    alohomora.eprint("""\n\n----------------------------------------------------------------
 Your new access key pair has been stored in the AWS configuration file {0} under the {1} profile.'
 To use this credential, call the AWS CLI with the --profile option (e.g. aws --profile {1} ec2 describe-instances).'
 ----------------------------------------------------------------\n\n""".format(filename, profile))
+
+
+def print_token(token):
+    """Print the AWS STS token to STDOUT for use with aws cli credential_process."""
+    print(json.dumps({
+        "Version": 1,
+        "AccessKeyId": token['Credentials']['AccessKeyId'],
+        "SecretAccessKey": token['Credentials']['SecretAccessKey'],
+        "SessionToken": token['Credentials']['SessionToken'],
+        "Expiration": token['Credentials']['Expiration'].isoformat()
+    }, indent=4))
+
+
+def cache(token, alohomora_profile):
+    """Write the AWS STS token to a cache file with Expiration Time."""
+
+    filename = os.path.expanduser("~/.alohomora.cache")
+    # Read in the existing cache file
+    cache = ConfigParser.RawConfigParser()
+    try:
+        cache.read(filename)
+    except ConfigParser.Error:
+        alohomora.eprint('Error reading your ~/.alohomora.cache configuration file.')
+
+    # This makes sure there is a [default] section if that's where
+    # the caller wants to put the profile. Don't ask me why this
+    # works when the cache.has_section() test below doesn't. Config
+    # be strange.
+    #
+    if alohomora_profile.lower() == 'default' and 'default' not in cache.sections():
+        cache.add_section('default')
+
+    # Put the credentials into a saml specific section instead of clobbering
+    # the default credentials
+    if not cache.has_section(alohomora_profile):
+        cache.add_section(alohomora_profile)
+
+    cache.set(alohomora_profile, 'aws_access_key_id', token['Credentials']['AccessKeyId'])
+    cache.set(alohomora_profile, 'aws_secret_access_key', token['Credentials']['SecretAccessKey'])
+    cache.set(alohomora_profile, 'aws_session_token', token['Credentials']['SessionToken'])
+    cache.set(alohomora_profile, 'exiration_time', token['Credentials']['Expiration'].isoformat())
+
+    # Write the updated cache file
+    with open(filename, 'w+') as cachefile:
+        cache.write(cachefile)
+
+
+def get_cache(alohomora_profile):
+    """Read and return non-expired cached credentials."""
+    filename = os.path.expanduser("~/.alohomora.cache")
+    # Read in the existing cache file
+    cache = ConfigParser.RawConfigParser()
+    try:
+        cache.read(filename)
+    except ConfigParser.Error:
+        alohomora.eprint('Error reading your ~/.alohomora.cache configuration file.')
+        return None
+
+    if not cache.has_section(alohomora_profile):
+        return None
+
+    token = {'Credentials': {}}
+    token['Credentials']['AccessKeyId'] = cache.get(alohomora_profile, 'aws_access_key_id')
+    token['Credentials']['SecretAccessKey'] = cache.get(alohomora_profile, 'aws_secret_access_key')
+    token['Credentials']['SessionToken'] = cache.get(alohomora_profile, 'aws_session_token')
+    token['Credentials']['Expiration'] = datetime.fromisoformat(cache.get(alohomora_profile, 'exiration_time'))
+
+    if token['Credentials']['Expiration'] > datetime.now(tz=timezone.utc):
+        return token
+
+    # Remove cached credentials that are now stale
+    cache.remove_section(alohomora_profile)
+    # Write the updated cache file
+    with open(filename, 'w+') as cachefile:
+        cache.write(cachefile)


### PR DESCRIPTION
See Issue #40 

NOTE:
This code currently has a major flaw in that the password prompt doesn't appear if being run as a credential_process within the awscli command.  STDIN is still passed to the process, and login succeeds,  but only if the user silently knows that STDIN has been grabbed by Alohomora and is expecting input which is dangerous.  A non-stdin method of password input would be required to use this.  Given that Im not sure this can be useful, but it was a fun POC none the less.

Also, ignore the changes,  I didn't turn off isort or autopep8 in my editor, so it mashed in lots of small fixes in some files.