### PR TITLE
Fix dist build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
+long_description_content_type = text/markdown


### PR DESCRIPTION
Twine was complaining about the `long_description` although we only set `description_file` in the setup.cfg. The warnings that show up hint at the fact that it can't infer the content-type of the description file based on filename 🤦 . Explicitly adding the content-type fixes this error and should allow us to publish. This error was likely a warning in the past due to the fact that the pypi package shows "The author of this package has not provided a project description" rather than the contents of the README.md file.