### PR TITLE
Freshen copyright, add long_description for pypi page

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022, Viasat, Inc.
+Copyright 2023, Viasat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this work except in compliance with the License.

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -1,6 +1,6 @@
 """Alohomora helper module"""
 
-# Copyright 2022 Viasat, Inc.
+# Copyright 2023 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import sys
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 __author__ = 'Viasat'
 __author_email__ = 'vice-support@viasat.com'
 __license__ = '(c) 2022 Viasat, Inc. See the LICENSE file for more details.'

--- a/alohomora/keys.py
+++ b/alohomora/keys.py
@@ -1,6 +1,6 @@
 """Handles getting and saving AWS API keys"""
 
-# Copyright 2022 Viasat, Inc.
+# Copyright 2023 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alohomora/main.py
+++ b/alohomora/main.py
@@ -2,7 +2,7 @@
 alohomora console script
 '''
 
-# Copyright 2022 Viasat, Inc.
+# Copyright 2023 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -1,6 +1,6 @@
 """The workhorse functions that make web requests."""
 
-# Copyright 2022 Viasat, Inc.
+# Copyright 2023 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alohomora/saml.py
+++ b/alohomora/saml.py
@@ -1,6 +1,6 @@
 """Does some work parsing SAML assertions"""
 
-# Copyright 2022 Viasat, Inc.
+# Copyright 2023 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2022 ViaSat, Inc.
+# Copyright 2023 ViaSat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@ import alohomora
 
 from setuptools import setup
 
+with open('README.md', 'r') as fh:
+    long_description = fh.read()
+
 setup(
     name='alohomora',
     version=alohomora.__version__,
@@ -23,6 +26,8 @@ setup(
     author_email=alohomora.__author_email__,
     license=alohomora.__license__,
     url=alohomora.__url__,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     description=alohomora.__description__,
 
     packages=['alohomora'],


### PR DESCRIPTION
Per the [packaging docs](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata), this should allow the [pypi page](https://pypi.org/project/alohomora/) to show the contents of the readme on the main page.