### PR TITLE
Change `mycompany.com` to `example.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ The file looks like a standard Python config file:
 
 ```ini
 [default]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+idp-url = https://sso.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 username = myuser
 ```
 
 A CLI-based version of this would be
 
 ```
-$ alohomora --username myuser --idp-url https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+$ alohomora --username myuser --idp-url https://sso.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 ```
 
 
@@ -100,7 +100,7 @@ $ alohomora --auth-method call
 
 ```ini
 [default]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+idp-url = https://sso.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
 ```
 
@@ -111,12 +111,12 @@ You can create multiple configuration profiles in the ~/.alohomora file, for exa
 
 ```ini
 [default]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+idp-url = https://sso.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
 role-name = a-fine-role
 
 [particularly-fine]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+idp-url = https://sso.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
 role-name = a-particularly-fine-role
 ```
@@ -184,7 +184,7 @@ configuration section like so:
 
 ```ini
 [default]
-idp-url = https://sso.mycompany.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+idp-url = https://sso.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
 auth-method = push
 account = 112233445566
 role-name = sso-admins

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -16,7 +16,7 @@
 
 import sys
 
-__version__ = '3.0.2'
+__version__ = '3.0.3'
 __author__ = 'Viasat'
 __author_email__ = 'vice-support@viasat.com'
 __license__ = '(c) 2022 Viasat, Inc. See the LICENSE file for more details.'


### PR DESCRIPTION
This change updates documentation references from `mycompany.com` to `example.com`.

The example.com domain has been set aside by iana for documentation purposes. The
mycompany.com domain does not come with such guarantees and could be used to intercept
valid credentials.
