### PR TITLE
Add workaround to cookies datetime parsing bug.

### DIFF
--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -16,7 +16,7 @@
 
 import sys
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 __author__ = 'Viasat'
 __author_email__ = 'vice-support@viasat.com'
 __license__ = '(c) 2022 Viasat, Inc. See the LICENSE file for more details.'

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -1,6 +1,6 @@
 """Alohomora helper module"""
 
-# Copyright 2023 Viasat, Inc.
+# Copyright 2024 Viasat, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import sys
 __version__ = '3.1.1'
 __author__ = 'Viasat'
 __author_email__ = 'vice-support@viasat.com'
-__license__ = '(c) 2022 Viasat, Inc. See the LICENSE file for more details.'
+__license__ = '(c) 2024 Viasat, Inc. See the LICENSE file for more details.'
 __url__ = 'https://github.com/Viasat/alohomora'
 __description__ = 'Get AWS API keys for a SAML-federated identity'
 


### PR DESCRIPTION
There is an incompatibility between the Python cookies and datetime packages in newer versions on Windows that causes an exception when saving cookies returned from posts to Duo. The workaround is to not save cookies returned from Duo.