### PR TITLE
catch failed cookie save

### DIFF
--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -16,7 +16,7 @@
 
 import sys
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 __author__ = 'Viasat'
 __author_email__ = 'vice-support@viasat.com'
 __license__ = '(c) 2022 Viasat, Inc. See the LICENSE file for more details.'

--- a/alohomora/__init__.py
+++ b/alohomora/__init__.py
@@ -19,7 +19,7 @@ import sys
 __version__ = '3.1.1'
 __author__ = 'Viasat'
 __author_email__ = 'vice-support@viasat.com'
-__license__ = '(c) 2022 Viasat, Inc. See the LICENSE file for more details.'
+__license__ = '(c) 2024 Viasat, Inc. See the LICENSE file for more details.'
 __url__ = 'https://github.com/Viasat/alohomora'
 __description__ = 'Get AWS API keys for a SAML-federated identity'
 

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -806,7 +806,13 @@ class DuoRequestsProvider(WebProvider):
         LOG.debug("Post cookie jar: %s", self.session.cookies)
         LOG.debug("Request headers: %s", response.request.headers)
         LOG.debug("Response headers: %s", response.headers)
-        self.session.cookies.save(ignore_discard=True, ignore_expires=True)
+        # On Windows the python builtin cookiejar chokes on a returned timestamps
+        # in a DUO cookie.  The role assumption still function, but subsequent calls will
+        # require password and MFA to be entered again when the cookie fails to save.
+        try:
+            self.session.cookies.save(ignore_discard=True, ignore_expires=True)
+        except OSError as err:
+            LOG.debug("WARN: unable to save cookie.")
         if soup:
             the_soup = BeautifulSoup(response.text, 'html.parser')
         else:

--- a/alohomora/req.py
+++ b/alohomora/req.py
@@ -22,6 +22,7 @@ import logging
 import time
 import os
 import base64
+from datetime import datetime, timedelta
 from http.cookiejar import LWPCookieJar
 
 try:
@@ -806,13 +807,16 @@ class DuoRequestsProvider(WebProvider):
         LOG.debug("Post cookie jar: %s", self.session.cookies)
         LOG.debug("Request headers: %s", response.request.headers)
         LOG.debug("Response headers: %s", response.headers)
-        # On Windows the python builtin cookiejar chokes on a returned timestamps
-        # in a DUO cookie.  The role assumption still function, but subsequent calls will
-        # require password and MFA to be entered again when the cookie fails to save.
-        try:
-            self.session.cookies.save(ignore_discard=True, ignore_expires=True)
-        except OSError as err:
-            LOG.debug("WARN: unable to save cookie.")
+        # On Windows the python builtin cookiejar chokes on a returned timestamp
+        # in the DUO status cookie.  It is set to expire far in the future in the
+        # year 9999.  Windows can not parse this timestamp, so we overwite it with
+        # an expiration 30 days in the future so it is parsable in Windows.
+        future_ts = (datetime.now() + timedelta(days=30)).timestamp()
+        for cookie in self.session.cookies:
+            if cookie.expires and cookie.expires > future_ts:
+                LOG.debug(f"rewrite coookie expires from: {cookie.expires} to: {future_ts}")
+                cookie.expires = future_ts
+        self.session.cookies.save(ignore_discard=True, ignore_expires=True)
         if soup:
             the_soup = BeautifulSoup(response.text, 'html.parser')
         else:


### PR DESCRIPTION
This PR adds a fix for windows.  The Duo status endpoint returns an expires timestamp far in the future (9999) and that is not parsable by datetime on Windows.  This rewrites that year 9999 timestamp to 30 days in the future.  This allows the application to work as expected on all platforms.